### PR TITLE
Delegate agent creation to configurable start function and remove stored config from state

### DIFF
--- a/lib/nex/agent/inbound_worker.ex
+++ b/lib/nex/agent/inbound_worker.ex
@@ -11,7 +11,6 @@ defmodule Nex.Agent.InboundWorker do
   alias Nex.Agent.{Bus, Config}
 
   defstruct [
-    :config,
     :agent_start_fun,
     :agent_prompt_fun,
     :agent_abort_fun,
@@ -26,7 +25,6 @@ defmodule Nex.Agent.InboundWorker do
   @type agent_abort_fun :: (term() -> :ok | {:error, term()})
 
   @type t :: %__MODULE__{
-          config: Config.t(),
           agent_start_fun: agent_start_fun(),
           agent_prompt_fun: agent_prompt_fun(),
           agent_abort_fun: agent_abort_fun(),
@@ -49,7 +47,6 @@ defmodule Nex.Agent.InboundWorker do
   @impl true
   def init(opts) do
     state = %__MODULE__{
-      config: Keyword.get(opts, :config, Config.load()),
       agent_start_fun: Keyword.get(opts, :agent_start_fun, &Nex.Agent.start/1),
       agent_prompt_fun: Keyword.get(opts, :agent_prompt_fun, &Nex.Agent.prompt/3),
       agent_abort_fun: Keyword.get(opts, :agent_abort_fun, &Nex.Agent.abort/1),
@@ -320,28 +317,14 @@ defmodule Nex.Agent.InboundWorker do
       :error ->
         opts = agent_start_opts(key)
 
-        session = Nex.Agent.SessionManager.get_or_create(key)
-        Logger.info("InboundWorker creating new agent session=#{session.key} for key=#{key}")
+        case state.agent_start_fun.(opts) do
+          {:ok, agent} ->
+            Logger.info("InboundWorker created new agent session=#{agent.session.key} for key=#{key}")
+            {:ok, agent, put_in(state.agents[key], agent)}
 
-        provider = Keyword.get(opts, :provider, :openai)
-        model = Keyword.get(opts, :model, "gpt-4o")
-        api_key = Keyword.get(opts, :api_key)
-        base_url = Keyword.get(opts, :base_url)
-        cwd = Keyword.get(opts, :cwd, File.cwd!())
-        max_iterations = Keyword.get(opts, :max_iterations, 40)
-
-        agent = %Nex.Agent{
-          session_key: key,
-          session: session,
-          provider: provider,
-          model: model,
-          api_key: api_key,
-          base_url: base_url,
-          cwd: cwd,
-          max_iterations: max_iterations
-        }
-
-        {:ok, agent, put_in(state.agents[key], agent)}
+          {:error, reason} ->
+            {:error, reason}
+        end
     end
   end
 
@@ -356,7 +339,6 @@ defmodule Nex.Agent.InboundWorker do
       model: config.model,
       api_key: Config.get_current_api_key(config),
       base_url: Config.get_current_base_url(config),
-      project: session_key,
       cwd: home,
       max_iterations: Config.get_max_iterations(config),
       channel: channel,

--- a/test/nex/agent/inbound_worker_test.exs
+++ b/test/nex/agent/inbound_worker_test.exs
@@ -73,8 +73,7 @@ defmodule Nex.Agent.InboundWorkerTest do
     assert_receive {:bus_message, :telegram_outbound, out2}, 1_000
     assert out2.content == "echo: second"
 
-    # ensure_agent creates agents directly now, start_fun is no longer called
-    assert Agent.get(start_count, & &1) == 0
+    assert Agent.get(start_count, & &1) == 1
   end
 
   test "supports /new and /stop control commands" do


### PR DESCRIPTION
### Motivation

- Decouple agent instantiation from `InboundWorker` so agent startup can be provided via a configurable `agent_start_fun` hook.  

### Description

- Remove the `config` field from the `InboundWorker` struct and its type since worker no longer keeps a persistent config value.  
- Change `ensure_agent/2` to call `state.agent_start_fun.(opts)` and handle `{:ok, agent}` and `{:error, reason}` results instead of constructing a `Nex.Agent` directly.  
- Update logging to reference the created agent session via `agent.session.key` when creation succeeds.  
- Remove the `project: session_key` entry from `agent_start_opts/1` so startup options no longer embed the session as `project`.  
- Adjust tests to reflect that the start function is invoked to create agents (update expected `start_count` assertion).  

### Testing

- Ran the `Nex.Agent.InboundWorker` unit tests in `test/nex/agent/inbound_worker_test.exs` which exercise session creation, message dispatch, and control commands, and they passed.  
- Ran the test suite covering inbound message handling and agent lifecycle behaviors, and the tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b03b8625ec8321bf28426adcedf034)