### PR TITLE
Add Japanese README (README.ja.md)

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -1,0 +1,569 @@
+<div align="center">
+  <h1>NexAgent</h1>
+  <p><strong>Votre agent IA auto-évolutif</strong></p>
+  <p>Un agent longue durée qui fonctionne dans les applications de chat que vous utilisez déjà, appelle des outils, mémorise le contexte et continue de s'améliorer grâce à une utilisation réelle.</p>
+  <p><a href="./README.md">English README</a> | <a href="./README.zh-CN.md">中文文档</a> | <a href="./README.ja.md">日本語</a> | <a href="./README.ko.md">한국어</a></p>
+</div>
+
+**NexAgent** est un agent IA conçu pour une utilisation réelle et à long terme.
+
+Ce n'est pas simplement une démo CLI ponctuelle, ni une fine couche de prompt autour d'un modèle. NexAgent est construit autour d'un objectif plus précis : maintenir un agent en ligne, le placer dans les applications de chat que vous utilisez déjà, lui donner de la mémoire et des outils, lui permettre de gérer des tâches en arrière-plan, et le rendre capable de s'améliorer au fil du temps.
+
+Deux idées définissent le projet aujourd'hui :
+
+- **Auto-évolution** : pas seulement l'ingénierie de prompt, mais aussi la mémoire, les compétences, les outils et l'auto-amélioration au niveau du code source.
+- **Elixir/OTP** : arbres de supervision, GenServers, isolation des processus et chargement à chaud de code pour la tolérance aux pannes, la concurrence et le fonctionnement à long terme.
+
+## At a Glance
+
+Si vous ne retenez que trois choses à propos de NexAgent :
+
+- **Ce que c'est** : un agent IA longue durée qui vit dans des applications de chat
+- **Ce qu'il peut faire** : mémoire, outils, compétences, tâches planifiées et travaux en arrière-plan
+- **Pourquoi il peut continuer à fonctionner** : Elixir/OTP avec des chemins d'auto-évolution intégrés
+
+```mermaid
+flowchart TD
+    A["Chat Apps<br/>Telegram / Feishu / Discord / Slack / DingTalk"] --> B["Gateway"]
+    B --> C["InboundWorker"]
+    C --> D["Runner"]
+    D --> E["Sessions + Memory"]
+    D --> F["Tools + Skills"]
+    D --> G["Cron + Subagent"]
+    D --> H["Reflect + Upgrade Code"]
+    H --> I["CodeUpgrade + UpgradeManager"]
+```
+
+## What You Can Build
+
+| Cas d'usage | Ce que fait NexAgent |
+| --- | --- |
+| Assistant toujours actif | Reste dans vos applications de chat et conserve le contexte de chaque conversation |
+| Agent de connaissance personnel | Combine mémoire à long terme, historique et recherche |
+| Assistant d'automatisation | Utilise cron pour les rappels, les tâches récurrentes et le travail en arrière-plan |
+| Agent en croissance | S'étend via les compétences, les outils et l'auto-amélioration au niveau du code |
+
+## Key Features
+
+| Capacité | Ce que cela signifie |
+| --- | --- |
+| **Auto-évolution par conception** | `soul_update`, `memory_write`, `skill_capture`, `tool_create`, `reflect` et `upgrade_code` empêchent l'agent de rester statique |
+| **Sessions longue durée** | Les sessions sont délimitées par `channel:chat_id` et conservent mémoire, historique et isolation |
+| **Fonctionne dans vos applications de chat** | Telegram, Feishu, Discord, Slack et DingTalk sont déjà pris en charge |
+| **Outils, compétences et mémoire intégrés** | Accès aux fichiers, shell, web, messagerie, recherche mémoire, planification et compétences inclus |
+| **Travail en arrière-plan inclus** | Les tâches Cron et les sous-agents font partie intégrante du système |
+| **Construit sur Elixir/OTP** | Arbres de supervision, processus de service et rechargement à chaud pour une disponibilité en production |
+
+## Why NexAgent
+
+De nombreux projets d'agents excellent dans l'exécution d'une tâche unique. NexAgent se concentre sur un ensemble différent de questions : une fois qu'un agent est réellement déployé dans des environnements de chat et maintenu en ligne, comment organiser les sessions, la mémoire, les tâches, la gestion des pannes et l'auto-amélioration ?
+
+### Pourquoi auto-évolutif
+
+NexAgent ne se différencie pas par « un outil de plus » ou « un modèle de plus ». Sa véritable différence est que l'évolution est traitée comme une capacité fondamentale du système.
+
+Ce chemin est organisé en couches :
+
+- `SOUL.md` : ajuster le comportement, le ton et les valeurs
+- `MEMORY.md` / `HISTORY.md` / journaux quotidiens : accumuler l'expérience à long terme
+- Compétences : transformer les nouvelles capacités en blocs de construction réutilisables
+- Outils : étendre ce que l'agent peut réellement faire
+- Code : utiliser `reflect` et `upgrade_code` pour inspecter et modifier l'agent lui-même
+
+Voilà pourquoi « auto-évolutif » n'est pas qu'un slogan ici. C'est une direction qui va du prompt et de la mémoire jusqu'au code source.
+
+### Pourquoi Elixir/OTP
+
+Si un agent ne s'exécute qu'occasionnellement, le runtime importe peu. S'il doit rester en ligne, gérer plusieurs surfaces de chat, exécuter des travaux en arrière-plan, se remettre des pannes et éventuellement se mettre à jour à chaud, OTP cesse d'être un détail d'implémentation et devient une partie du produit.
+
+NexAgent suit déjà ce chemin dans le code :
+
+- `Application` gère l'infrastructure, les workers et les cycles de vie des canaux via un arbre de supervision
+- `Gateway` gère les connexions aux applications de chat
+- `InboundWorker` consomme les messages entrants et achemine les sessions
+- `SessionManager`, `Tool.Registry`, `Cron` et `Subagent` fonctionnent comme des services longue durée
+- `CodeUpgrade` et `UpgradeManager` gèrent les mises à jour à chaud, le versionnage et les chemins de retour arrière
+
+C'est pourquoi Elixir/OTP n'est pas un détail anecdotique dans ce projet. C'est l'une des principales raisons pour lesquelles le projet existe sous cette forme.
+
+## What Makes It Different
+
+NexAgent n'essaie pas de résoudre « comment wrapper un appel de modèle de plus ». Il essaie de résoudre un ensemble de problèmes plus opérationnels :
+
+| Prototype d'agent traditionnel | Ce que NexAgent vise |
+| --- | --- |
+| Tâches ponctuelles dans un CLI | Agents longue durée dans les applications de chat |
+| Dépend principalement de la fenêtre de contexte actuelle | Sessions, mémoire, historique et recherche |
+| Les nouvelles capacités viennent principalement des modifications de prompt | Outils, compétences et auto-amélioration au niveau du code |
+| Les échecs tendent à tuer tout le tour | La supervision OTP et les services longue durée maintiennent la stabilité |
+| Les capacités sont généralement fixes après le déploiement | L'agent continue d'évoluer pendant son fonctionnement |
+
+## Install
+
+### À partir des sources
+
+Prérequis :
+
+- Elixir `~> 1.18`
+- Erlang/OTP
+
+Installer les dépendances :
+
+```bash
+git clone https://github.com/gofenix/nex-agent.git
+cd nex-agent
+mix deps.get
+```
+
+## Quick Start
+
+### 1. Initialisation
+
+```bash
+mix nex.agent onboard
+```
+
+Vous pouvez également pointer le CLI vers une instance spécifique :
+
+```bash
+mix nex.agent -c /path/to/config.json -w /path/to/workspace onboard
+```
+
+Lors de la première exécution, NexAgent crée la configuration et l'espace de travail pour cette instance :
+
+```text
+~/.nex/agent/
+├── config.json
+├── tools/
+└── workspace/
+    ├── AGENTS.md
+    ├── SOUL.md
+    ├── USER.md
+    ├── skills/
+    ├── sessions/
+    └── memory/
+        ├── MEMORY.md
+        ├── HISTORY.md
+        └── YYYY-MM-DD/log.md
+```
+
+### 2. Configuration du modèle
+
+La méthode la plus directe consiste à définir le fournisseur, le modèle et la clé API via le CLI :
+
+```bash
+mix nex.agent config set provider openai
+mix nex.agent config set model gpt-4o
+mix nex.agent config set api_key openai sk-xxx
+```
+
+Si vous souhaitez utiliser Ollama :
+
+```bash
+mix nex.agent config set provider ollama
+mix nex.agent config set model llama3.1
+```
+
+Fournisseurs par défaut :
+
+- `anthropic`
+- `openai`
+- `openrouter`
+- `ollama`
+
+L'accès aux fournisseurs est unifié via `req_llm`, donc NexAgent n'a plus besoin d'un module client écrit séparément pour chaque fournisseur.
+
+Emplacement du fichier de configuration :
+
+```text
+~/.nex/agent/config.json
+```
+
+Si vous passez `--config` sans définir `defaults.workspace`, l'espace de travail par défaut est `Path.dirname(config.json)/workspace` pour cette instance.
+
+### 3. Chat
+
+Le CLI est un shell hôte pour le runtime de l'agent. Les actions spécifiques aux capacités restent dans la boucle de l'agent via les outils et les compétences ; le CLI lui-même ne gère que les sessions et l'état du runtime.
+
+Message unique :
+
+```bash
+mix nex.agent -m "hello"
+```
+
+Mode interactif :
+
+```bash
+mix nex.agent
+```
+
+### 4. Lancer la passerelle
+
+```bash
+mix nex.agent gateway
+```
+
+Vérifier le statut :
+
+```bash
+mix nex.agent status
+```
+
+Cibler une instance spécifique :
+
+```bash
+mix nex.agent -c /path/to/config.json status
+mix nex.agent -c /path/to/config.json -w /path/to/workspace gateway
+```
+
+Arrêter la passerelle :
+
+```bash
+mix nex.agent gateway stop
+```
+
+## Chat Apps
+
+NexAgent n'est pas conçu pour vivre uniquement dans un terminal.
+
+L'objectif est de placer l'agent dans les applications de chat que vous utilisez déjà, afin qu'il fasse partie de la communication et des flux de travail réels.
+
+Canaux actuellement pris en charge dans le code :
+
+| Canal | Ce dont vous avez besoin |
+| --- | --- |
+| Telegram | Jeton de bot |
+| Feishu | App ID + App Secret |
+| Discord | Jeton de bot |
+| Slack | Jeton de bot + jeton au niveau application |
+| DingTalk | App Key + App Secret |
+
+### Telegram
+
+Telegram est le moyen le plus simple de commencer.
+
+1. Créez un bot via `@BotFather`
+2. Configurez Telegram dans `config.json` ou via le CLI
+3. Lancez la passerelle
+
+Exemple :
+
+```bash
+mix nex.agent config set telegram.enabled true
+mix nex.agent config set telegram.token 123456:ABCDEF
+mix nex.agent config set telegram.allow_from 10001,10002
+mix nex.agent config set telegram.reply_to_message true
+mix nex.agent gateway
+```
+
+Les autres applications de chat sont mieux configurées directement dans `~/.nex/agent/config.json`.
+
+### Feishu et Lark CLI
+
+Feishu est toujours pris en charge en tant que canal de chat.
+
+Ce qui a changé, c'est la surface d'automatisation de l'espace de travail :
+
+- NexAgent n'inclut plus d'outils métier `feishu_*` intégrés pour Docs, Sheets, Base, Calendar, Tasks, Drive, l'administration du chat ou la recherche.
+- Pour ces opérations, utilisez l'outil `bash` existant avec `lark-cli` externe.
+- `lark-cli` n'est pas vendu ni auto-installé par NexAgent. Installez-le séparément depuis [larksuite/cli](https://github.com/larksuite/cli).
+- Si `lark-cli` est manquant, l'erreur shell doit être affichée directement, suivie d'une indication d'installation.
+
+## Models
+
+NexAgent prend actuellement en charge :
+
+- Anthropic
+- OpenAI
+- OpenRouter
+- Ollama
+
+Les points de départ les plus simples sont généralement :
+
+- Modèle cloud : OpenAI ou OpenRouter
+- Modèle local : Ollama
+
+`Runner` gère la boucle de l'agent et dispatch vers l'implémentation du fournisseur sélectionné.
+
+## Tools and Skills
+
+### Outils intégrés
+
+Outils intégrés par défaut :
+
+- `read`
+- `write`
+- `edit`
+- `list_dir`
+- `bash`
+- `web_search`
+- `web_fetch`
+- `message`
+- `memory_write`
+- `cron`
+- `spawn_task`
+- `skill_discover`
+- `skill_get`
+- `skill_capture`
+- `skill_import`
+- `skill_sync`
+- `tool_list`
+- `tool_create`
+- `tool_delete`
+- `soul_update`
+- `reflect`
+- `upgrade_code`
+
+Ensemble, ils couvrent les fichiers, les commandes shell, l'accès web, la messagerie sortante, la mémoire à long terme, la planification, la croissance des compétences, la croissance des outils et les mises à niveau de code.
+
+### Outils globaux personnalisés
+
+Les outils Elixir personnalisés résident dans `~/.nex/agent/workspace/tools/<name>/` et sont enregistrés comme des outils de première classe.
+
+- `tool_create` crée un outil personnalisé dans l'espace de travail
+- `tool_list` inspecte les outils intégrés et personnalisés
+- `tool_delete` supprime un outil personnalisé
+
+### Compétences
+
+Au-delà des outils, NexAgent dispose d'un système de compétences basé sur Markdown.
+
+Les compétences sont des modules de workflow réutilisables qui aident l'agent à :
+
+- empaqueter des workflows
+- standardiser des tâches récurrentes
+- créer des instructions réutilisables pour lui-même
+
+Les paquets de compétences runtime locaux à l'instance résident dans `workspace/skills/<name>/`. Découvrez-les via `skill_discover`, inspectez-les via `skill_get`, et capturez de nouveaux paquets de connaissances locales via `skill_capture`.
+
+Les politiques de workflow appartenant au dépôt peuvent également résider dans `.nex/skills/<name>/SKILL.md`. Lorsque `skill_runtime.enabled` est activé, les compétences Markdown locales au dépôt sont migrées vers des paquets gérés par le runtime sous `workspace/skills/rt__*`.
+
+Les capacités basées sur le code appartiennent au système d'outils, où les modules Elixir implémentent un comportement déterministe via `Tool.Behaviour`.
+
+### Tests E2E SkillRuntime
+
+- La couverture E2E hermétique s'exécute via `Runner.run/3`, des espaces de travail temporaires, un `Tool.Registry` réel, des appels LLM simulés et des réponses GitHub simulées. Ces tests sont inclus dans le chemin `mix test` par défaut et sont étiquetés `:e2e`.
+- La couverture E2E en direct est étiquetée `:live_e2e` et est exclue des séries de test par défaut. Utilisez `mix test --only live_e2e` lorsque `OPENAI_API_KEY` est défini. Le chemin d'importation en direct GitHub nécessite également `GH_TOKEN` ou `GITHUB_TOKEN`.
+- Le fichier de test en direct GitHub par défaut pointe vers le dépôt en cours de test via `SKILL_RUNTIME_LIVE_REPO`, `SKILL_RUNTIME_LIVE_COMMIT_SHA` et `SKILL_RUNTIME_LIVE_PATH`. Dans GitHub Actions, les valeurs par défaut sont `${GITHUB_REPOSITORY}`, `${GITHUB_SHA}` et `test/support/fixtures/skill_runtime/live_packages/live_echo_playbook`.
+- Le CI par défaut exécute la suite hermétique via `mix test`. Les tests E2E en direct ne s'exécutent que dans le workflow manuel/quotidien dédié.
+
+## Memory and Sessions
+
+Les sessions NexAgent ne sont pas de simples fenêtres de contexte éphémères. Ce sont des conversations persistantes avec des couches de mémoire en arrière-plan.
+
+### Sessions
+
+Les sessions sont délimitées par `channel:chat_id`, par exemple :
+
+- `telegram:123456`
+- `discord:channel_id`
+
+Cela maintient l'isolation des différentes surfaces de chat au lieu de tout mélanger dans un seul flux de conversation.
+
+Des commandes de contrôle de base existent déjà :
+
+- `/new` : démarrer une nouvelle session
+- `/stop` : arrêter les tâches actives de la session en cours
+
+### Memory
+
+Le système de mémoire est organisé en couches :
+
+- `MEMORY.md` : mémoire à long terme
+- `HISTORY.md` : historique consultable
+- Journal quotidien `YYYY-MM-DD/log.md` : mémoire opérationnelle et expérience accumulée
+- `Memory.Index` : recherche de type BM25
+
+Le but de cette conception est simple :
+
+- l'agent ne doit pas repartir de zéro à chaque fois
+- tout ne doit pas être poussé dans le prompt
+- la mémoire à long terme, l'historique et l'expérience quotidienne doivent jouer des rôles différents
+
+## Six-Layer Growth
+
+C'est l'une des capacités déterminantes de NexAgent.
+
+Son évolution ne se produit pas à un seul point. Elle se produit en six couches.
+
+- `SOUL` : qui est l'agent et quels principes à long terme il suit
+- `USER` : qui est l'utilisateur et comment l'agent doit collaborer avec lui
+- `MEMORY` : faits durables sur l'environnement, le projet et le contexte opérationnel
+- `SKILL` : workflows réutilisables et connaissances procédurales
+- `TOOL` : capacités exécutables déterministes
+- `CODE` : mises à niveau de l'implémentation interne
+
+### Soul
+
+`SOUL.md` ajuste le comportement, la personnalité et les valeurs.
+
+### User
+
+`USER.md` capture qui est l'utilisateur, comment il préfère collaborer et ce qui doit rester stable entre les sessions.
+
+### Memory
+
+Via `MEMORY.md`, `HISTORY.md` et les journaux quotidiens, l'agent peut continuer à accumuler des faits durables sur le projet et l'environnement au lieu de dépendre uniquement de la fenêtre de chat actuelle.
+
+### Skills
+
+Via `skill_capture`, l'agent peut continuer à étendre les workflows réutilisables et les connaissances procédurales. La découverte est unifiée via `skill_discover` et `skill_get`, tandis que les compétences de type paquet fiables peuvent être importées et actualisées via `skill_import` et `skill_sync`.
+
+### Tools
+
+Via `tool_create` et les outils personnalisés de l'espace de travail, l'agent peut continuer à étendre ses capacités exécutables déterministes.
+
+### Code evolution
+
+La couche code a son propre chemin de mise à niveau explicite :
+
+- `reflect` : inspecter le code source du module, l'historique et les différences
+- `upgrade_code` : soumettre le code de module mis à jour
+- `CodeUpgrade` : sauvegarder, valider, compiler, charger et versionner le code
+- `UpgradeManager` : coordonner les mises à niveau de code, les échanges à chaud et les chemins de retour arrière
+
+C'est ce qui rend NexAgent plus qu'un agent configurable. C'est un système d'agent explicitement conçu pour apprendre, s'étendre et se mettre à niveau à travers plusieurs couches.
+
+```mermaid
+flowchart LR
+    A["Reflect<br/>Read source / history / diff"] --> B["Understand<br/>Find the problem or opportunity"]
+    B --> C["Upgrade Code<br/>Submit new code"]
+    C --> D["CodeUpgrade<br/>Backup / validate / compile / load"]
+    D --> E["UpgradeManager<br/>Hot-swap / rollback protection"]
+    E --> F["Agent keeps running"]
+```
+
+## Automation
+
+### Cron
+
+NexAgent inclut un outil `cron` intégré pour les tâches planifiées.
+
+Opérations prises en charge :
+
+- ajouter des tâches
+- lister les tâches
+- activer / désactiver des tâches
+- déclencher des tâches manuellement
+- inspecter le statut des tâches
+
+Modes de planification pris en charge :
+
+- `every_seconds`
+- `cron_expr`
+- `at`
+
+Pour réduire les coûts d'exécution à long terme, l'exécution cron est délibérément allégée :
+
+- portée d'outil réduite
+- moins d'historique
+- chargement de compétences ignoré dans les exécutions légères
+- isolation de la session principale de l'utilisateur
+
+### Subagent
+
+`spawn_task` crée un sous-agent d'arrière-plan pour une tâche indépendante.
+
+Il convient aux cas comme :
+
+- travaux de longue durée
+- sous-problèmes parallélisables
+- tâches d'arrière-plan qui ne doivent pas bloquer la session principale
+
+Lorsqu'il se termine, le résultat est renvoyé via le bus.
+
+## Architecture
+
+NexAgent n'est pas une collection informe de scripts. C'est un système en couches, conçu pour une exécution à long terme.
+
+```mermaid
+flowchart TB
+    subgraph L1["Entry Layer"]
+        A["Chat Apps"]
+        B["Gateway"]
+    end
+
+    subgraph L2["Agent Layer"]
+        C["InboundWorker"]
+        D["Runner"]
+    end
+
+    subgraph L3["Capability Layer"]
+        E["Sessions"]
+        F["Memory + Memory.Index"]
+        G["Tools + Tool.Registry"]
+        H["Skills"]
+    end
+
+    subgraph L4["Background Layer"]
+        I["Cron"]
+        J["Subagent"]
+    end
+
+    subgraph L5["Code Layer"]
+        K["Reflect + Upgrade Code"]
+        L["CodeUpgrade + UpgradeManager"]
+    end
+
+    A --> B --> C --> D
+    D --> E
+    D --> F
+    D --> G
+    D --> H
+    D --> I
+    D --> J
+    D --> K --> L
+```
+
+Une autre façon de lire le système :
+
+- **Couche d'entrée** : Chat Apps + Gateway
+- **Couche agent** : InboundWorker + Runner
+- **Couche de capacités** : Tools + Skills + Memory + Sessions
+- **Couche d'arrière-plan** : Cron + Subagent
+- **Modèle de croissance en six couches** : Soul + User + Memory + Skill + Tool + Code
+
+Rôles principaux dans le code :
+
+- `Gateway` : gérer les processus de connexion aux applications de chat
+- `InboundWorker` : router les messages entrants
+- `Runner` : construire le contexte et exécuter la boucle de l'agent
+- `SessionManager` : gérer les sessions persistées
+- `Memory` / `Memory.Index` : gérer la mémoire à long terme et la recherche
+- `Tool.Registry` : gérer les outils dynamiquement
+- `Skills` : charger et exécuter les compétences
+- `Cron` : gérer les tâches planifiées
+- `Subagent` : gérer les sous-agents d'arrière-plan
+- `CodeUpgrade` / `UpgradeManager` : gérer les mises à niveau de code au niveau source
+
+Ces parties sont maintenues ensemble par un arbre de supervision OTP plutôt que d'être dispersées dans des scripts sans rapport.
+
+## Security
+
+NexAgent a déjà des limites importantes en place :
+
+- l'accès aux fichiers est restreint aux racines autorisées
+- le traversement de chemin est validé
+- l'exécution shell dispose d'une liste blanche et d'un blocage de motifs dangereux
+- les applications de chat prennent en charge `allow_from`
+- l'exécution cron et sous-agent utilise des chemins plus restreints
+
+Ce n'est pas terminé, mais la direction est claire : il n'est pas destiné à devenir un agent local sans restriction par défaut.
+
+## Closing
+
+Si vous deviez résumer le projet en une ligne :
+
+> NexAgent est un agent IA auto-évolutif construit sur Elixir/OTP pour une utilisation réelle et à long terme.
+
+Son facteur de différenciation n'est pas simplement « un fournisseur de plus » ou « quelques outils supplémentaires ». C'est la tentative de combiner tout cela dans un seul système :
+
+- fonctionnement à long terme
+- présence dans les applications de chat
+- sessions et mémoire persistantes
+- outils et compétences extensibles
+- tâches planifiées et sous-agents d'arrière-plan
+- auto-amélioration au niveau du code source
+- tolérance aux pannes et mises à jour à chaud basées sur OTP
+
+Si vous vous souciez de la façon dont les agents peuvent continuer à exister dans des environnements réels, et pas seulement accomplir une tâche de démonstration unique, c'est la voie que NexAgent ouvre.

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,569 @@
+<div align="center">
+  <h1>NexAgent</h1>
+  <p><strong>自己進化する AI エージェント</strong></p>
+  <p>使い慣れたチャットアプリの中で動作し、ツールを呼び出し、コンテキストを記憶し、実際の使用を通じて進化し続ける長期稼働エージェントです。</p>
+  <p><a href="./README.md">English README</a> | <a href="./README.zh-CN.md">中文文档</a></p>
+</div>
+
+NexAgent は、実際の使用シーンに向けて構築された AI エージェントです。
+
+単発の CLI デモではなく、モデルの単なるプロンプトラッパーでもありません。NexAgent はより明確な目標を持っています：エージェントを常時オンラインにし、使い慣れたチャットアプリの中に配置し、記憶とツールを与え、バックグラウンド作業を管理させ、時間の経過とともに改善できるようにすることです。
+
+このプロジェクトを定義する 2 つの核心理念：
+
+- **自己進化**：プロンプトエンジニアリングだけでなく、記憶、スキル、ツール、そしてソースコードレベルの自己改善
+- **Elixir/OTP**：監督ツリー、GenServer、プロセス分離、ホットコードローディングによる耐障害性、並行処理、長期運用
+
+## At a Glance
+
+NexAgent について覚えておくべき 3 つのポイント：
+
+- **何か**：チャットアプリ内で動作する長期稼働 AI エージェント
+- **何ができるか**：記憶、ツール、スキル、スケジュールジョブ、バックグラウンドタスク
+- **なぜ稼働し続けられるか**：Elixir/OTP ＋ 自己進化パス
+
+```mermaid
+flowchart TD
+    A["Chat Apps<br/>Telegram / Feishu / Discord / Slack / DingTalk"] --> B["Gateway"]
+    B --> C["InboundWorker"]
+    C --> D["Runner"]
+    D --> E["Sessions + Memory"]
+    D --> F["Tools + Skills"]
+    D --> G["Cron + Subagent"]
+    D --> H["Reflect + Upgrade Code"]
+    H --> I["CodeUpgrade + UpgradeManager"]
+```
+
+## What You Can Build
+
+| ユースケース | NexAgent の動作 |
+| --- | --- |
+| 常時稼働アシスタント | チャットアプリ内で常に稼働し、チャットごとのコンテキストを維持 |
+| パーソナルナレッジエージェント | 長期記憶、履歴、検索を組み合わせる |
+| 自動化アシスタント | cron によるリマインダー、定期ジョブ、バックグラウンド作業 |
+| 成長するエージェント | スキル、ツール、コードレベルの自己改善を通じて拡張 |
+
+## Key Features
+
+| 機能 | 説明 |
+| --- | --- |
+| **設計による自己進化** | `soul_update`、`memory_write`、`skill_capture`、`tool_create`、`reflect`、`upgrade_code` によりエージェントは静的になりません |
+| **長期稼働セッション** | セッションは `channel:chat_id` でスコープされ、記憶、履歴、分離を維持 |
+| **チャットアプリで動作** | Telegram、Feishu、Discord、Slack、DingTalk に対応 |
+| **ツール、スキル、記憶を内蔵** | ファイルアクセス、シェル、Web、メッセージング、記憶検索、スケジューリング、スキルが標準装備 |
+| **バックグラウンド作業も標準** | Cron ジョブとサブエージェントがシステムの一部として組み込まれています |
+| **Elixir/OTP ベース** | 監督ツリー、サービスプロセス、ホットリロードで実運用の稼働時間をサポート |
+
+## Why NexAgent
+
+多くのエージェントプロジェクトは単一タスクの完了に優れています。NexAgent は別の問いに焦点を当てています：エージェントが実際にチャット環境にデプロイされ、常時オンラインになったとき、セッション、記憶、ジョブ、障害処理、自己改善をどのように構成すべきか。
+
+### 自己進化する理由
+
+NexAgent の差別化要因は「もう一つのツール」や「もう一つのモデル」ではありません。本当の違いは、進化をコアシステム機能として扱っていることです。
+
+そのパスは階層化されています：
+
+- `SOUL.md`：行動、トーン、価値観を調整
+- `MEMORY.md` / `HISTORY.md` / 日次ログ：長期経験を蓄積
+- スキル：新しい能力を再利用可能なビルディングブロックに変換
+- ツール：エージェントが実際にできることを拡張
+- コード：`reflect` と `upgrade_code` を使用してエージェント自身を検査・変更
+
+「自己進化」は単なるスローガンではありません。プロンプトと記憶からソースコードに至るまで、全ての方向に及ぶ指針です。
+
+### Elixir/OTP を選ぶ理由
+
+エージェントがたまにしか動作しないのであれば、ランタイムはそれほど重要ではありません。しかし、常時オンラインを維持し、複数のチャットサーフェスを管理し、バックグラウンド作業を実行し、障害から回復し、最終的に自身をホットアップグレードする必要がある場合、OTP は実装の詳細ではなく、プロダクトの一部になります。
+
+NexAgent はすでにコード上でこのパスを実践しています：
+
+- `Application` が監督ツリーを通じてインフラ、ワーカー、チャネルのライフサイクルを管理
+- `Gateway` がチャットアプリの接続を管理
+- `InboundWorker` がインバウンドメッセージを消費し、セッションをルーティング
+- `SessionManager`、`Tool.Registry`、`Cron`、`Subagent` が長期稼働サービスとして動作
+- `CodeUpgrade` と `UpgradeManager` がホットアップデート、バージョン管理、ロールバックパスを処理
+
+これが Elixir/OTP がこのプロジェクトの背景情報ではなく、このプロジェクトがこの形で存在する主要な理由の一つである理由です。
+
+## What Makes It Different
+
+NexAgent は「もう一つのモデル呼び出しをラップする方法」を解決しようとしているのではありません。より運用上の問題を解決しようとしています：
+
+| 従来のエージェントプロトタイプ | NexAgent が目指すもの |
+| --- | --- |
+| CLI での単発タスク | チャットアプリ内の長期稼働エージェント |
+| 主に現在のコンテキストウィンドウに依存 | セッション、記憶、履歴、検索 |
+| 新機能は主にプロンプト編集 | ツール、スキル、コードレベルの自己改善 |
+| 障害はターン全体を中断しがち | OTP 監督と長期稼働サービスでシステム安定性を維持 |
+| 機能はデプロイ後ほぼ固定 | 稼働中もエージェントは進化し続ける |
+
+## Install
+
+### ソースから
+
+必要条件：
+
+- Elixir `~> 1.18`
+- Erlang/OTP
+
+依存関係のインストール：
+
+```bash
+git clone https://github.com/gofenix/nex-agent.git
+cd nex-agent
+mix deps.get
+```
+
+## Quick Start
+
+### 1. 初期化
+
+```bash
+mix nex.agent onboard
+```
+
+特定のインスタンスを指定することもできます：
+
+```bash
+mix nex.agent -c /path/to/config.json -w /path/to/workspace onboard
+```
+
+初回実行時に NexAgent は設定とワークスペースを作成します：
+
+```text
+~/.nex/agent/
+├── config.json
+├── tools/
+└── workspace/
+    ├── AGENTS.md
+    ├── SOUL.md
+    ├── USER.md
+    ├── skills/
+    ├── sessions/
+    └── memory/
+        ├── MEMORY.md
+        ├── HISTORY.md
+        └── YYYY-MM-DD/log.md
+```
+
+### 2. モデルの設定
+
+最も直接的な方法は CLI を使用して provider、model、API key を設定することです：
+
+```bash
+mix nex.agent config set provider openai
+mix nex.agent config set model gpt-4o
+mix nex.agent config set api_key openai sk-xxx
+```
+
+Ollama を使用する場合：
+
+```bash
+mix nex.agent config set provider ollama
+mix nex.agent config set model llama3.1
+```
+
+デフォルトのプロバイダー：
+
+- `anthropic`
+- `openai`
+- `openrouter`
+- `ollama`
+
+プロバイダーアクセスは `req_llm` を通じて統一されているため、プロバイダーごとに個別のクライアントモジュールは不要です。
+
+設定ファイルの場所：
+
+```text
+~/.nex/agent/config.json
+```
+
+`--config` を指定し `defaults.workspace` を設定しない場合、ワークスペースのデフォルトは `config.json` のあるディレクトリの `workspace/` になります。
+
+### 3. チャット
+
+CLI はエージェントランタイムのホストシェルです。具体的な機能はエージェントループがツールとスキルを通じてセッション内で処理します。
+
+単発メッセージ：
+
+```bash
+mix nex.agent -m "hello"
+```
+
+対話モード：
+
+```bash
+mix nex.agent
+```
+
+### 4. ゲートウェイの起動
+
+```bash
+mix nex.agent gateway
+```
+
+ステータス確認：
+
+```bash
+mix nex.agent status
+```
+
+特定のインスタンスを指定：
+
+```bash
+mix nex.agent -c /path/to/config.json status
+mix nex.agent -c /path/to/config.json -w /path/to/workspace gateway
+```
+
+ゲートウェイの停止：
+
+```bash
+mix nex.agent gateway stop
+```
+
+## Chat Apps
+
+NexAgent はターミナルだけで動作することを想定していません。
+
+目標は、使い慣れたチャットアプリの中にエージェントを配置し、実際のコミュニケーションとワークフローの一部にすることです。
+
+コード上ですでに対応しているチャネル：
+
+| チャネル | 必要なもの |
+| --- | --- |
+| Telegram | Bot Token |
+| Feishu | App ID + App Secret |
+| Discord | Bot Token |
+| Slack | Bot Token + App-Level Token |
+| DingTalk | App Key + App Secret |
+
+### Telegram
+
+Telegram は最も始めやすいチャネルです。
+
+1. `@BotFather` でボットを作成
+2. `config.json` または CLI で Telegram を設定
+3. ゲートウェイを起動
+
+例：
+
+```bash
+mix nex.agent config set telegram.enabled true
+mix nex.agent config set telegram.token 123456:ABCDEF
+mix nex.agent config set telegram.allow_from 10001,10002
+mix nex.agent config set telegram.reply_to_message true
+mix nex.agent gateway
+```
+
+その他のチャットアプリは `~/.nex/agent/config.json` を直接編集して設定することをお勧めします。
+
+### Feishu と Lark CLI
+
+Feishu はチャットチャネルとして引き続きサポートされています。
+
+変更されたのはワークスペース自動化の部分です：
+
+- NexAgent は Docs、Sheets、Base、Calendar、Tasks、Drive、チャット管理、検索用の `feishu_*` ビジネスツールを内蔵しなくなりました。
+- これらの操作には、既存の `bash` ツールから外部の `lark-cli` を呼び出してください。
+- `lark-cli` は NexAgent にバンドルまたは自動インストールされません。[larksuite/cli](https://github.com/larksuite/cli) から個別にインストールしてください。
+- `lark-cli` がない場合、シェルエラーをそのまま表示し、インストールのヒントを提示します。
+
+## Models
+
+NexAgent は現在以下のプロバイダーをサポートしています：
+
+- Anthropic
+- OpenAI
+- OpenRouter
+- Ollama
+
+最もシンプルな開始点：
+
+- クラウドモデル：OpenAI または OpenRouter
+- ローカルモデル：Ollama
+
+`Runner` がエージェントループを処理し、選択されたプロバイダーの実装にディスパッチします。
+
+## Tools and Skills
+
+### 組み込みツール
+
+デフォルトの組み込みツール：
+
+- `read`
+- `write`
+- `edit`
+- `list_dir`
+- `bash`
+- `web_search`
+- `web_fetch`
+- `message`
+- `memory_write`
+- `cron`
+- `spawn_task`
+- `skill_discover`
+- `skill_get`
+- `skill_capture`
+- `skill_import`
+- `skill_sync`
+- `tool_list`
+- `tool_create`
+- `tool_delete`
+- `soul_update`
+- `reflect`
+- `upgrade_code`
+
+これらでファイル、シェルコマンド、Web アクセス、アウトバウンドメッセージング、長期記憶、スケジューリング、スキル成長、ツール成長、コードアップグレードをカバーします。
+
+### カスタムグローバルツール
+
+カスタム Elixir ツールは `~/.nex/agent/workspace/tools/<name>/` に配置され、第一級ツールとして登録されます。
+
+- `tool_create` はワークスペースカスタムツールを作成
+- `tool_list` は組み込みツールとカスタムツールを表示
+- `tool_delete` はカスタムツールを削除
+
+### スキル
+
+ツールに加えて、NexAgent には Markdown ベースのスキルシステムがあります。
+
+スキルはエージェントが以下のことを行うための再利用可能なワークフローモジュールです：
+
+- ワークフローのパッケージ化
+- 繰り返しタスクの標準化
+- 自身のための再利用可能な指示を作成
+
+インスタンスローカルのランタイムスキルパッケージは `workspace/skills/<name>/` にあります。`skill_discover` で発見し、`skill_get` で調査し、`skill_capture` で新しいローカルナレッジパッケージを取り込みます。
+
+リポジトリ所有のワークフローポリシーは `.nex/skills/<name>/SKILL.md` にも配置できます。`skill_runtime.enabled` が有効な場合、リポジトリローカルの Markdown スキルは `workspace/skills/rt__*` にマイグレーションされ、ランタイムによって管理されます。
+
+コードベースの機能はツールシステムに属し、Elixir モジュールが `Tool.Behaviour` を通じて決定論的な動作を実装します。
+
+### SkillRuntime E2E テスト
+
+- Hemetic E2E は `Runner.run/3`、一時ワークスペース、実際の `Tool.Registry`、スタブ LLM、スタブ GitHub レスポンスを通じてパス全体をカバーします。これらのテストはデフォルトの `mix test` に含まれ、`:e2e` タグが付いています。
+- Live E2E には `:live_e2e` タグが付いており、デフォルトのテスト実行からは除外されています。`OPENAI_API_KEY` が設定されている場合は `mix test --only live_e2e` で実行できます。GitHub のライブインポートパスには `GH_TOKEN` または `GITHUB_TOKEN` も必要です。
+- ライブ GitHub フィクスチャはデフォルトで `SKILL_RUNTIME_LIVE_REPO`、`SKILL_RUNTIME_LIVE_COMMIT_SHA`、`SKILL_RUNTIME_LIVE_PATH` を介してテスト対象のリポジトリを指します。GitHub Actions ではデフォルトで `${GITHUB_REPOSITORY}`、`${GITHUB_SHA}`、`test/support/fixtures/skill_runtime/live_packages/live_echo_playbook` になります。
+- デフォルトの CI は `mix test` で Hemetic スイートを実行します。Live E2E は専用の手動/ナイトリー CI ワークフローでのみ実行されます。
+
+## Memory and Sessions
+
+NexAgent のセッションは単なる短命なコンテキストウィンドウではありません。背後にメモリレイヤーを持つ永続的な会話です。
+
+### Sessions
+
+セッションは `channel:chat_id` でスコープされます。例：
+
+- `telegram:123456`
+- `discord:channel_id`
+
+これにより、異なるチャットサーフェスが分離され、すべてがひとつの会話ストリームに混ざることがありません。
+
+基本的な制御コマンド：
+
+- `/new`：新しいセッションを開始
+- `/stop`：現在のセッションのアクティブなタスクを停止
+
+### Memory
+
+メモリシステムは階層化されています：
+
+- `MEMORY.md`：長期記憶
+- `HISTORY.md`：検索可能な履歴
+- 日次 `YYYY-MM-DD/log.md`：運用記憶と蓄積された経験
+- `Memory.Index`：BM25 スタイルの検索
+
+この設計のポイントはシンプルです：
+
+- エージェントが毎回ゼロから始める必要はない
+- すべてをプロンプトに詰め込むべきではない
+- 長期記憶、履歴、日々の経験がそれぞれ異なる役割を果たす
+
+## Six-Layer Growth
+
+これは NexAgent の最も特徴的な能力の一つです。
+
+進化は単一のポイントで起こるのではなく、6 つの階層で行われます。
+
+- `SOUL`：エージェントのアイデンティティと長期的な行動原則
+- `USER`：ユーザーのプロファイルとコラボレーションの好み
+- `MEMORY`：環境、プロジェクト、運用コンテキストに関する永続的な事実
+- `SKILL`：再利用可能なワークフローと手続き的知識
+- `TOOL`：決定論的な実行可能能力
+- `CODE`：内部実装のアップグレード
+
+### Soul
+
+`SOUL.md` は行動、性格、価値観を調整します。
+
+### User
+
+`USER.md` はユーザーが誰であるか、どのようなコラボレーションを好むか、セッション間で安定させるべき情報を保持します。
+
+### Memory
+
+`MEMORY.md`、`HISTORY.md`、日次ログを通じて、エージェントは現在のチャットウィンドウだけに依存せず、耐久性のあるプロジェクトや環境の事実を蓄積し続けることができます。
+
+### Skills
+
+`skill_capture` を通じて、エージェントは再利用可能なワークフローと手続き的知識を拡張し続けることができます。発見は `skill_discover` と `skill_get` で統一され、信頼できるパッケージスタイルのスキルは `skill_import` と `skill_sync` でインポートおよび更新できます。
+
+### Tools
+
+`tool_create` とワークスペースカスタムツールを通じて、エージェントは決定論的な実行可能能力を拡張し続けることができます。
+
+### Code evolution
+
+コードレイヤーには独自の明示的なアップグレードパスがあります：
+
+- `reflect`：モジュールのソース、履歴、差分を検査
+- `upgrade_code`：更新されたモジュールコードを送信
+- `CodeUpgrade`：バックアップ、検証、コンパイル、ロード、バージョン管理
+- `UpgradeManager`：コードアップグレード、ホットスワップ、ロールバックパスを調整
+
+これにより、NexAgent は単なる設定可能なエージェント以上のものになっています。明示的に学習、拡張、複数の階層で自身をアップグレードするように構築されたエージェントシステムです。
+
+```mermaid
+flowchart LR
+    A["Reflect<br/>Read source / history / diff"] --> B["Understand<br/>Find the problem or opportunity"]
+    B --> C["Upgrade Code<br/>Submit new code"]
+    C --> D["CodeUpgrade<br/>Backup / validate / compile / load"]
+    D --> E["UpgradeManager<br/>Hot-swap / rollback protection"]
+    E --> F["Agent keeps running"]
+```
+
+## Automation
+
+### Cron
+
+NexAgent にはスケジュールジョブ用の組み込み `cron` ツールが含まれています。
+
+サポートされている操作：
+
+- ジョブの追加
+- ジョブの一覧表示
+- ジョブの有効化 / 無効化
+- ジョブの手動トリガー
+- ジョブステータスの確認
+
+サポートされているスケジュールモード：
+
+- `every_seconds`
+- `cron_expr`
+- `at`
+
+長期稼働コストを削減するため、cron 実行は意図的に軽量化されています：
+
+- ツール範囲の制限
+- 履歴の削減
+- 軽量実行ではスキル読み込みをスキップ
+- ユーザーのメインセッションからの分離
+
+### Subagent
+
+`spawn_task` は独立したタスク用のバックグラウンドサブエージェントを作成します。
+
+以下のようなケースに適しています：
+
+- 長時間実行作業
+- 並列化可能なサブ問題
+- メインセッションをブロックすべきでないバックグラウンドタスク
+
+完了すると、結果はバスを通じて送り返されます。
+
+## Architecture
+
+NexAgent はスクリプトの寄せ集めではありません。階層化された長期稼働システムです。
+
+```mermaid
+flowchart TB
+    subgraph L1["Entry Layer"]
+        A["Chat Apps"]
+        B["Gateway"]
+    end
+
+    subgraph L2["Agent Layer"]
+        C["InboundWorker"]
+        D["Runner"]
+    end
+
+    subgraph L3["Capability Layer"]
+        E["Sessions"]
+        F["Memory + Memory.Index"]
+        G["Tools + Tool.Registry"]
+        H["Skills"]
+    end
+
+    subgraph L4["Background Layer"]
+        I["Cron"]
+        J["Subagent"]
+    end
+
+    subgraph L5["Code Layer"]
+        K["Reflect + Upgrade Code"]
+        L["CodeUpgrade + UpgradeManager"]
+    end
+
+    A --> B --> C --> D
+    D --> E
+    D --> F
+    D --> G
+    D --> H
+    D --> I
+    D --> J
+    D --> K --> L
+```
+
+別の見方：
+
+- **エントリーレイヤー**：Chat Apps + Gateway
+- **エージェントレイヤー**：InboundWorker + Runner
+- **ケイパビリティレイヤー**：Tools + Skills + Memory + Sessions
+- **バックグラウンドレイヤー**：Cron + Subagent
+- **6 層成長モデル**：Soul + User + Memory + Skill + Tool + Code
+
+コード上の主要な役割：
+
+- `Gateway`：チャットアプリ接続プロセスの管理
+- `InboundWorker`：インバウンドメッセージのルーティング
+- `Runner`：コンテキスト構築とエージェントループの実行
+- `SessionManager`：永続化セッションの管理
+- `Memory` / `Memory.Index`：長期記憶と検索の管理
+- `Tool.Registry`：ツールの動的管理
+- `Skills`：スキルの読み込みと実行
+- `Cron`：スケジュールジョブの管理
+- `Subagent`：バックグラウンドサブエージェントの管理
+- `CodeUpgrade` / `UpgradeManager`：ソースレベルコードアップグレードの管理
+
+これらのコンポーネントは OTP 監督ツリーによって統合され、無関係なスクリプトに分散することはありません。
+
+## Security
+
+NexAgent はすでにいくつかの重要な境界を設定しています：
+
+- ファイルアクセスは許可されたルートに制限
+- パストラバーサルは検証
+- シェル実行にはホワイトリストと危険パターンブロッキング
+- チャットアプリは `allow_from` をサポート
+- cron とサブエージェントの実行はより制限されたパスを使用
+
+まだ完成ではありませんが、方向性は明確です：デフォルトで無制限のローカル権限エージェントになることを意図していません。
+
+## Closing
+
+プロジェクトを一文にまとめると：
+
+> NexAgent は、Elixir/OTP 上に構築された、長期稼働・実運用向けの自己進化型 AI エージェントです。
+
+差別化要因は「もう一つのプロバイダー」や「あといくつかのツール」だけではありません。以下のすべてをひとつのシステムに組み合わせようとしている点にあります：
+
+- 長期稼働
+- チャットアプリへの常駐
+- 永続的なセッションと記憶
+- 拡張可能なツールとスキル
+- スケジュールジョブとバックグラウンドサブエージェント
+- ソースコードレベルの自己改善
+- OTP による耐障害性とホットアップグレード
+
+実際の環境でエージェントがどのように存在し続けるかに関心があるなら、それが NexAgent が推し進めている道です。

--- a/README.ja.md
+++ b/README.ja.md
@@ -2,7 +2,7 @@
   <h1>NexAgent</h1>
   <p><strong>自己進化する AI エージェント</strong></p>
   <p>使い慣れたチャットアプリの中で動作し、ツールを呼び出し、コンテキストを記憶し、実際の使用を通じて進化し続ける長期稼働エージェントです。</p>
-  <p><a href="./README.md">English README</a> | <a href="./README.zh-CN.md">中文文档</a></p>
+  <p><a href="./README.md">English README</a> | <a href="./README.zh-CN.md">中文文档</a> | <a href="./README.ko.md">한국어</a></p>
 </div>
 
 NexAgent は、実際の使用シーンに向けて構築された AI エージェントです。

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,0 +1,569 @@
+<div align="center">
+  <h1>NexAgent</h1>
+  <p><strong>스스로 진화하는 AI 에이전트</strong></p>
+  <p>이미 사용 중인 채팅 앱에서 작동하며, 도구를 호출하고, 컨텍스트를 기억하고, 실제 사용을 통해 계속해서 발전하는 장기 실행 에이전트입니다.</p>
+  <p><a href="./README.md">English README</a> | <a href="./README.zh-CN.md">中文文档</a> | <a href="./README.ja.md">日本語</a></p>
+</div>
+
+**NexAgent**는 실제 장기 실행 환경을 위해 구축된 AI 에이전트입니다.
+
+일회성 CLI 데모나 단순한 프롬프트 래퍼가 아닙니다. NexAgent는 더 구체적인 목표를 가지고 있습니다: 에이전트를 항상 온라인 상태로 유지하고, 이미 사용 중인 채팅 앱 안에 배치하며, 메모리와 도구를 제공하고, 백그라운드 작업을 관리하게 하며, 시간이 지남에 따라 개선될 수 있도록 하는 것입니다.
+
+이 프로젝트를 정의하는 두 가지 핵심 개념:
+
+- **자기 진화**: 프롬프트 엔지니어링뿐만 아니라 메모리, 스킬, 도구, 소스 코드 수준의 자기 개선
+- **Elixir/OTP**: 감독 트리, GenServer, 프로세스 격리, 핫 코드 로딩을 통한 내결함성, 동시성, 장기 운영
+
+## At a Glance
+
+NexAgent에 대해 꼭 기억해야 할 세 가지:
+
+- **무엇인가**: 채팅 앱 안에서 작동하는 장기 실행 AI 에이전트
+- **무엇을 할 수 있는가**: 메모리, 도구, 스킬, 예약 작업, 백그라운드 태스크
+- **왜 계속 실행될 수 있는가**: Elixir/OTP + 내장 자기 진화 경로
+
+```mermaid
+flowchart TD
+    A["Chat Apps<br/>Telegram / Feishu / Discord / Slack / DingTalk"] --> B["Gateway"]
+    B --> C["InboundWorker"]
+    C --> D["Runner"]
+    D --> E["Sessions + Memory"]
+    D --> F["Tools + Skills"]
+    D --> G["Cron + Subagent"]
+    D --> H["Reflect + Upgrade Code"]
+    H --> I["CodeUpgrade + UpgradeManager"]
+```
+
+## What You Can Build
+
+| 사용 사례 | NexAgent의 역할 |
+| --- | --- |
+| 상시 대기 어시스턴트 | 채팅 앱에 항상 대기하며 채팅별 컨텍스트 유지 |
+| 개인 지식 에이전트 | 장기 메모리, 기록, 검색 결합 |
+| 자동화 어시스턴트 | cron을 사용한 알림, 정기 작업, 백그라운드 작업 |
+| 성장하는 에이전트 | 스킬, 도구, 코드 수준 자기 개선을 통해 확장 |
+
+## Key Features
+
+| 기능 | 설명 |
+| --- | --- |
+| **설계에 의한 자기 진화** | `soul_update`, `memory_write`, `skill_capture`, `tool_create`, `reflect`, `upgrade_code`로 에이전트가 정체되지 않음 |
+| **장기 실행 세션** | 세션은 `channel:chat_id`로 범위가 지정되며 메모리, 기록, 격리 유지 |
+| **채팅 앱에서 작동** | Telegram, Feishu, Discord, Slack, DingTalk 지원 |
+| **내장 도구, 스킬, 메모리** | 파일 접근, 셸, 웹, 메시징, 메모리 검색, 스케줄링, 스킬 기본 탑재 |
+| **백그라운드 작업 포함** | Cron 작업과 서브에이전트가 시스템의 일부로 내장 |
+| **Elixir/OTP 기반** | 감독 트리, 서비스 프로세스, 핫 리로드로 실제 운영 가동 시간 지원 |
+
+## Why NexAgent
+
+많은 에이전트 프로젝트는 단일 작업을 완료하는 데 능숙합니다. NexAgent는 다른 질문에 집중합니다: 에이전트가 실제로 채팅 환경에 배포되어 항상 온라인 상태가 되면, 세션, 메모리, 작업, 장애 처리, 자기 개선을 어떻게 구성해야 할까요?
+
+### 자기 진화를 선택한 이유
+
+NexAgent의 차별점은 "또 하나의 도구"나 "또 하나의 모델"이 아닙니다. 진화를 핵심 시스템 기능으로 취급한다는 점이 진정한 차이입니다.
+
+그 경로는 계층화되어 있습니다:
+
+- `SOUL.md`: 행동, 어조, 가치관 조정
+- `MEMORY.md` / `HISTORY.md` / 일일 로그: 장기 경험 축적
+- 스킬: 새로운 능력을 재사용 가능한 빌딩 블록으로 전환
+- 도구: 에이전트가 실제로 할 수 있는 일 확장
+- 코드: `reflect`와 `upgrade_code`를 사용하여 에이전트 자체 검사 및 수정
+
+이것이 "자기 진화"가 단순한 슬로건이 아닌 이유입니다. 프롬프트와 메모리에서 소스 코드까지 모든 방향으로 이어지는 지침입니다.
+
+### Elixir/OTP를 선택한 이유
+
+에이전트가 가끔만 실행된다면 런타임은 그다지 중요하지 않습니다. 하지만 항상 온라인 상태를 유지하고, 여러 채팅 서피스를 관리하고, 백그라운드 작업을 실행하고, 장애에서 복구하고, 결국 스스로 핫 업그레이드해야 한다면 OTP는 구현 세부 사항이 아니라 제품의 일부가 됩니다.
+
+NexAgent는 이미 코드에서 이 경로를 따르고 있습니다:
+
+- `Application`이 감독 트리를 통해 인프라, 워커, 채널 라이프사이클 관리
+- `Gateway`가 채팅 앱 연결 관리
+- `InboundWorker`가 인바운드 메시지 소비 및 세션 라우팅
+- `SessionManager`, `Tool.Registry`, `Cron`, `Subagent`가 장기 실행 서비스로 작동
+- `CodeUpgrade`와 `UpgradeManager`가 핫 업데이트, 버전 관리, 롤백 경로 처리
+
+이것이 Elixir/OTP가 이 프로젝트의 배경 정보가 아니라, 이 프로젝트가 이런 형태로 존재하는 주요 이유 중 하나인 이유입니다.
+
+## What Makes It Different
+
+NexAgent는 "모델 호출을 하나 더 래핑하는 방법"을 해결하려는 것이 아닙니다. 더 운영적인 문제 세트를 해결하려고 합니다:
+
+| 기존 에이전트 프로토타입 | NexAgent가 지향하는 것 |
+| --- | --- |
+| CLI에서의 일회성 작업 | 채팅 앱 안의 장기 실행 에이전트 |
+| 주로 현재 컨텍스트 윈도우에 의존 | 세션, 메모리, 기록, 검색 |
+| 새 기능은 주로 프롬프트 편집 | 도구, 스킬, 코드 수준 자기 개선 |
+| 장애는 보통 전체 턴을 중단시킴 | OTP 감독과 장기 실행 서비스로 시스템 안정성 유지 |
+| 기능은 배포 후 거의 고정됨 | 실행 중에도 에이전트가 계속 진화 |
+
+## Install
+
+### 소스에서 설치
+
+요구 사항:
+
+- Elixir `~> 1.18`
+- Erlang/OTP
+
+의존성 설치:
+
+```bash
+git clone https://github.com/gofenix/nex-agent.git
+cd nex-agent
+mix deps.get
+```
+
+## Quick Start
+
+### 1. 초기화
+
+```bash
+mix nex.agent onboard
+```
+
+특정 인스턴스를 지정할 수도 있습니다:
+
+```bash
+mix nex.agent -c /path/to/config.json -w /path/to/workspace onboard
+```
+
+첫 실행 시 NexAgent가 해당 인스턴스의 설정과 워크스페이스를 생성합니다:
+
+```text
+~/.nex/agent/
+├── config.json
+├── tools/
+└── workspace/
+    ├── AGENTS.md
+    ├── SOUL.md
+    ├── USER.md
+    ├── skills/
+    ├── sessions/
+    └── memory/
+        ├── MEMORY.md
+        ├── HISTORY.md
+        └── YYYY-MM-DD/log.md
+```
+
+### 2. 모델 설정
+
+가장 직접적인 방법은 CLI를 통해 provider, model, API key를 설정하는 것입니다:
+
+```bash
+mix nex.agent config set provider openai
+mix nex.agent config set model gpt-4o
+mix nex.agent config set api_key openai sk-xxx
+```
+
+Ollama를 사용하는 경우:
+
+```bash
+mix nex.agent config set provider ollama
+mix nex.agent config set model llama3.1
+```
+
+기본 제공자:
+
+- `anthropic`
+- `openai`
+- `openrouter`
+- `ollama`
+
+제공자 접근은 `req_llm`을 통해 통합되어 있으므로 제공자별로 별도의 클라이언트 모듈이 필요하지 않습니다.
+
+설정 파일 위치:
+
+```text
+~/.nex/agent/config.json
+```
+
+`--config`를 전달하고 `defaults.workspace`를 설정하지 않은 경우, 워크스페이스는 기본적으로 `config.json`이 있는 디렉토리의 `workspace/`가 됩니다.
+
+### 3. 채팅
+
+CLI는 에이전트 런타임의 호스트 셸입니다. 구체적인 기능은 에이전트 루프가 도구와 스킬을 통해 세션 내에서 처리합니다.
+
+단일 메시지:
+
+```bash
+mix nex.agent -m "hello"
+```
+
+대화형 모드:
+
+```bash
+mix nex.agent
+```
+
+### 4. 게이트웨이 실행
+
+```bash
+mix nex.agent gateway
+```
+
+상태 확인:
+
+```bash
+mix nex.agent status
+```
+
+특정 인스턴스 대상:
+
+```bash
+mix nex.agent -c /path/to/config.json status
+mix nex.agent -c /path/to/config.json -w /path/to/workspace gateway
+```
+
+게이트웨이 중지:
+
+```bash
+mix nex.agent gateway stop
+```
+
+## Chat Apps
+
+NexAgent는 터미널에서만 작동하도록 만들어지지 않았습니다.
+
+목표는 이미 사용 중인 채팅 앱 안에 에이전트를 배치하여 실제 커뮤니케이션과 워크플로의 일부가 되는 것입니다.
+
+현재 코드에서 지원되는 채널:
+
+| 채널 | 필요한 것 |
+| --- | --- |
+| Telegram | 봇 토큰 |
+| Feishu | App ID + App Secret |
+| Discord | 봇 토큰 |
+| Slack | 봇 토큰 + App-Level 토큰 |
+| DingTalk | App Key + App Secret |
+
+### Telegram
+
+Telegram은 가장 시작하기 쉬운 채널입니다.
+
+1. `@BotFather`를 통해 봇 생성
+2. `config.json` 또는 CLI에서 Telegram 설정
+3. 게이트웨이 시작
+
+예시:
+
+```bash
+mix nex.agent config set telegram.enabled true
+mix nex.agent config set telegram.token 123456:ABCDEF
+mix nex.agent config set telegram.allow_from 10001,10002
+mix nex.agent config set telegram.reply_to_message true
+mix nex.agent gateway
+```
+
+다른 채팅 앱은 `~/.nex/agent/config.json`을 직접 편집하여 설정하는 것이 좋습니다.
+
+### Feishu와 Lark CLI
+
+Feishu는 여전히 채팅 채널로 지원됩니다.
+
+변경된 것은 워크스페이스 자동화 부분입니다:
+
+- NexAgent는 더 이상 Docs, Sheets, Base, Calendar, Tasks, Drive, 채팅 관리, 검색용 `feishu_*` 비즈니스 도구를 내장하지 않습니다.
+- 이러한 작업에는 기존 `bash` 도구를 통해 외부 `lark-cli`를 사용하세요.
+- `lark-cli`는 NexAgent에 번들로 포함되거나 자동 설치되지 않습니다. [larksuite/cli](https://github.com/larksuite/cli)에서 별도로 설치하세요.
+- `lark-cli`가 없는 경우 셸 오류를 그대로 표시하고 설치 힌트를 제공합니다.
+
+## Models
+
+NexAgent는 현재 다음 제공자를 지원합니다:
+
+- Anthropic
+- OpenAI
+- OpenRouter
+- Ollama
+
+가장 간단한 시작점:
+
+- 클라우드 모델: OpenAI 또는 OpenRouter
+- 로컬 모델: Ollama
+
+`Runner`가 에이전트 루프를 처리하고 선택된 제공자 구현으로 디스패치합니다.
+
+## Tools and Skills
+
+### 내장 도구
+
+기본 내장 도구:
+
+- `read`
+- `write`
+- `edit`
+- `list_dir`
+- `bash`
+- `web_search`
+- `web_fetch`
+- `message`
+- `memory_write`
+- `cron`
+- `spawn_task`
+- `skill_discover`
+- `skill_get`
+- `skill_capture`
+- `skill_import`
+- `skill_sync`
+- `tool_list`
+- `tool_create`
+- `tool_delete`
+- `soul_update`
+- `reflect`
+- `upgrade_code`
+
+이 도구들은 파일, 셸 명령, 웹 접근, 아웃바운드 메시징, 장기 메모리, 스케줄링, 스킬 성장, 도구 성장, 코드 업그레이드를 포괄합니다.
+
+### 사용자 정의 전역 도구
+
+사용자 정의 Elixir 도구는 `~/.nex/agent/workspace/tools/<name>/`에 위치하며 일급 도구로 등록됩니다.
+
+- `tool_create`는 워크스페이스 사용자 정의 도구 생성
+- `tool_list`는 내장 및 사용자 정의 도구 조회
+- `tool_delete`는 사용자 정의 도구 삭제
+
+### 스킬
+
+도구 외에도 NexAgent는 Markdown 기반 스킬 시스템을 갖추고 있습니다.
+
+스킬은 에이전트가 다음을 수행할 수 있는 재사용 가능한 워크플로 모듈입니다:
+
+- 워크플로 패키징
+- 반복 작업 표준화
+- 자신을 위한 재사용 가능한 지침 생성
+
+인스턴스 로컬 런타임 스킬 패키지는 `workspace/skills/<name>/`에 있습니다. `skill_discover`로 발견하고, `skill_get`으로 조사하며, `skill_capture`로 새로운 로컬 지식 패키지를 캡처합니다.
+
+저장소 소유 워크플로 정책은 `.nex/skills/<name>/SKILL.md`에도 배치할 수 있습니다. `skill_runtime.enabled`가 활성화되면 저장소 로컬 Markdown 스킬이 `workspace/skills/rt__*`로 마이그레이션되어 런타임이 관리합니다.
+
+코드 기반 기능은 도구 시스템에 속하며, Elixir 모듈이 `Tool.Behaviour`를 통해 결정론적 동작을 구현합니다.
+
+### SkillRuntime E2E 테스트
+
+- Hermetic E2E는 `Runner.run/3`, 임시 워크스페이스, 실제 `Tool.Registry`, 스텁 LLM, 스텁 GitHub 응답을 통해 전체 경로를 커버합니다. 이 테스트는 기본 `mix test`에 포함되며 `:e2e` 태그가 지정됩니다.
+- Live E2E는 `:live_e2e` 태그가 지정되며 기본 테스트 실행에서 제외됩니다. `OPENAI_API_KEY`가 설정된 경우 `mix test --only live_e2e`로 실행할 수 있습니다. GitHub 라이브 가져오기 경로에는 `GH_TOKEN` 또는 `GITHUB_TOKEN`도 필요합니다.
+- 라이브 GitHub fixture는 기본적으로 `SKILL_RUNTIME_LIVE_REPO`, `SKILL_RUNTIME_LIVE_COMMIT_SHA`, `SKILL_RUNTIME_LIVE_PATH`를 통해 테스트 중인 저장소를 가리킵니다. GitHub Actions에서는 기본값이 `${GITHUB_REPOSITORY}`, `${GITHUB_SHA}`, `test/support/fixtures/skill_runtime/live_packages/live_echo_playbook`입니다.
+- 기본 CI는 `mix test`로 Hermetic 스위트를 실행합니다. Live E2E는 전용 수동/야간 워크플로에서만 실행됩니다.
+
+## Memory and Sessions
+
+NexAgent 세션은 단기 컨텍스트 윈도우가 아닙니다. 뒤에 메모리 레이어가 있는 영구적인 대화입니다.
+
+### Sessions
+
+세션은 `channel:chat_id`로 범위가 지정됩니다. 예:
+
+- `telegram:123456`
+- `discord:channel_id`
+
+이렇게 하면 다른 채팅 서피스가 분리되어 모든 것이 하나의 대화 스트림에 섞이지 않습니다.
+
+기본 제어 명령:
+
+- `/new`: 새 세션 시작
+- `/stop`: 현재 세션의 활성 작업 중지
+
+### Memory
+
+메모리 시스템은 계층화되어 있습니다:
+
+- `MEMORY.md`: 장기 메모리
+- `HISTORY.md`: 검색 가능한 기록
+- 일일 `YYYY-MM-DD/log.md`: 운영 메모리 및 축적된 경험
+- `Memory.Index`: BM25 스타일 검색
+
+이 설계의 요점은 간단합니다:
+
+- 에이전트가 매번 처음부터 시작할 필요가 없음
+- 모든 것을 프롬프트에 밀어넣지 않음
+- 장기 메모리, 기록, 일일 경험이 각각 다른 역할을 수행
+
+## Six-Layer Growth
+
+이것은 NexAgent의 가장 특징적인 능력 중 하나입니다.
+
+진화는 단일 지점에서 발생하지 않습니다. 6개 계층에서 발생합니다.
+
+- `SOUL`: 에이전트의 정체성과 장기 행동 원칙
+- `USER`: 사용자 프로필 및 협업 선호도
+- `MEMORY`: 환경, 프로젝트, 운영 컨텍스트에 대한 내구성 있는 사실
+- `SKILL`: 재사용 가능한 워크플로와 절차적 지식
+- `TOOL`: 결정론적 실행 가능 능력
+- `CODE`: 내부 구현 업그레이드
+
+### Soul
+
+`SOUL.md`는 행동, 성격, 가치관을 조정합니다.
+
+### User
+
+`USER.md`는 사용자가 누구인지, 어떻게 협업하기를 선호하는지, 세션 간에 안정적으로 유지해야 할 정보를 담습니다.
+
+### Memory
+
+`MEMORY.md`, `HISTORY.md`, 일일 로그를 통해 에이전트는 현재 채팅 창에만 의존하지 않고 내구성 있는 프로젝트 및 환경 사실을 계속 축적할 수 있습니다.
+
+### Skills
+
+`skill_capture`를 통해 에이전트는 재사용 가능한 워크플로와 절차적 지식을 계속 확장할 수 있습니다. 발견은 `skill_discover`와 `skill_get`을 통해 통일되며, 신뢰할 수 있는 패키지 스타일 스킬은 `skill_import`와 `skill_sync`를 통해 가져오고 업데이트할 수 있습니다.
+
+### Tools
+
+`tool_create`와 워크스페이스 사용자 정의 도구를 통해 에이전트는 결정론적 실행 가능 능력을 계속 확장할 수 있습니다.
+
+### Code evolution
+
+코드 계층에는 자체적인 명시적 업그레이드 경로가 있습니다:
+
+- `reflect`: 모듈 소스, 기록, 차이점 검사
+- `upgrade_code`: 업데이트된 모듈 코드 제출
+- `CodeUpgrade`: 백업, 검증, 컴파일, 로드, 버전 관리
+- `UpgradeManager`: 코드 업그레이드, 핫 스왑, 롤백 경로 조정
+
+이것이 NexAgent를 단순한 설정 가능한 에이전트 이상으로 만듭니다. 명시적으로 학습, 확장, 여러 계층에서 스스로 업그레이드하도록 구축된 에이전트 시스템입니다.
+
+```mermaid
+flowchart LR
+    A["Reflect<br/>Read source / history / diff"] --> B["Understand<br/>Find the problem or opportunity"]
+    B --> C["Upgrade Code<br/>Submit new code"]
+    C --> D["CodeUpgrade<br/>Backup / validate / compile / load"]
+    D --> E["UpgradeManager<br/>Hot-swap / rollback protection"]
+    E --> F["Agent keeps running"]
+```
+
+## Automation
+
+### Cron
+
+NexAgent에는 예약 작업을 위한 내장 `cron` 도구가 포함되어 있습니다.
+
+지원되는 작업:
+
+- 작업 추가
+- 작업 목록 보기
+- 작업 활성화 / 비활성화
+- 작업 수동 트리거
+- 작업 상태 확인
+
+지원되는 스케줄링 모드:
+
+- `every_seconds`
+- `cron_expr`
+- `at`
+
+장기 실행 비용을 줄이기 위해 cron 실행은 의도적으로 가볍게 설계되었습니다:
+
+- 더 좁은 도구 범위
+- 더 적은 기록
+- 경량 실행에서는 스킬 로딩 생략
+- 사용자의 메인 세션과 격리
+
+### Subagent
+
+`spawn_task`는 독립적인 작업을 위한 백그라운드 서브에이전트를 생성합니다.
+
+다음과 같은 경우에 적합합니다:
+
+- 장시간 실행 작업
+- 병렬화 가능한 하위 문제
+- 메인 세션을 차단하지 말아야 할 백그라운드 작업
+
+완료되면 결과가 버스를 통해 다시 전송됩니다.
+
+## Architecture
+
+NexAgent는 스크립트의 느슨한 집합이 아닙니다. 계층화된 장기 실행 시스템입니다.
+
+```mermaid
+flowchart TB
+    subgraph L1["Entry Layer"]
+        A["Chat Apps"]
+        B["Gateway"]
+    end
+
+    subgraph L2["Agent Layer"]
+        C["InboundWorker"]
+        D["Runner"]
+    end
+
+    subgraph L3["Capability Layer"]
+        E["Sessions"]
+        F["Memory + Memory.Index"]
+        G["Tools + Tool.Registry"]
+        H["Skills"]
+    end
+
+    subgraph L4["Background Layer"]
+        I["Cron"]
+        J["Subagent"]
+    end
+
+    subgraph L5["Code Layer"]
+        K["Reflect + Upgrade Code"]
+        L["CodeUpgrade + UpgradeManager"]
+    end
+
+    A --> B --> C --> D
+    D --> E
+    D --> F
+    D --> G
+    D --> H
+    D --> I
+    D --> J
+    D --> K --> L
+```
+
+다른 관점:
+
+- **진입 계층**: Chat Apps + Gateway
+- **에이전트 계층**: InboundWorker + Runner
+- **역량 계층**: Tools + Skills + Memory + Sessions
+- **백그라운드 계층**: Cron + Subagent
+- **6계층 성장 모델**: Soul + User + Memory + Skill + Tool + Code
+
+코드상의 핵심 역할:
+
+- `Gateway`: 채팅 앱 연결 프로세스 관리
+- `InboundWorker`: 인바운드 메시지 라우팅
+- `Runner`: 컨텍스트 구축 및 에이전트 루프 실행
+- `SessionManager`: 영구 세션 관리
+- `Memory` / `Memory.Index`: 장기 메모리 및 검색 관리
+- `Tool.Registry`: 도구 동적 관리
+- `Skills`: 스킬 로딩 및 실행
+- `Cron`: 예약 작업 관리
+- `Subagent`: 백그라운드 서브에이전트 관리
+- `CodeUpgrade` / `UpgradeManager`: 소스 코드 업그레이드 관리
+
+이러한 구성 요소는 OTP 감독 트리로 통합되어 있으며, 관련 없는 스크립트에 흩어져 있지 않습니다.
+
+## Security
+
+NexAgent는 이미 몇 가지 중요한 경계를 설정하고 있습니다:
+
+- 파일 접근은 허용된 루트로 제한
+- 경로 탐색은 검증
+- 셸 실행에는 화이트리스트와 위험 패턴 차단
+- 채팅 앱은 `allow_from` 지원
+- cron과 서브에이전트 실행은 더 제한된 경로 사용
+
+아직 완성되지 않았지만 방향은 명확합니다: 기본적으로 무제한 로컬 권한 에이전트가 되는 것을 의도하지 않습니다.
+
+## Closing
+
+프로젝트를 한 줄로 요약하면:
+
+> NexAgent는 Elixir/OTP 기반으로 구축된, 장기 실행 및 실제 운영을 위한 자기 진화형 AI 에이전트입니다.
+
+차별점은 "또 하나의 제공자"나 "몇 가지 더 많은 도구"만이 아닙니다. 다음 모든 것을 하나의 시스템에 결합하려는 시도입니다:
+
+- 장기 실행 운영
+- 채팅 앱 상주
+- 영구 세션 및 메모리
+- 확장 가능한 도구와 스킬
+- 예약 작업 및 백그라운드 서브에이전트
+- 소스 코드 수준의 자기 개선
+- OTP 기반 내결함성 및 핫 업그레이드
+
+에이전트가 실제 환경에서 어떻게 존재할 수 있는지에 관심이 있다면,それが NexAgent가 추진하는 길입니다.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <h1>NexAgent</h1>
   <p><strong>Your own self-evolving AI agent</strong></p>
   <p>A long-running agent that works in the chat apps you already use, calls tools, remembers context, and keeps improving through real-world use.</p>
-  <p><a href="./README.zh-CN.md">中文文档</a> | <a href="./README.ja.md">日本語</a> | <a href="./README.ko.md">한국어</a></p>
+  <p><a href="./README.zh-CN.md">中文文档</a> | <a href="./README.ja.md">日本語</a> | <a href="./README.ko.md">한국어</a> | <a href="./README.fr.md">Français</a></p>
 </div>
 
 **NexAgent** is an AI agent built for real-world, long-running use.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <h1>NexAgent</h1>
   <p><strong>Your own self-evolving AI agent</strong></p>
   <p>A long-running agent that works in the chat apps you already use, calls tools, remembers context, and keeps improving through real-world use.</p>
-  <p><a href="./README.zh-CN.md">中文文档</a></p>
+  <p><a href="./README.zh-CN.md">中文文档</a> | <a href="./README.ja.md">日本語</a></p>
 </div>
 
 **NexAgent** is an AI agent built for real-world, long-running use.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <h1>NexAgent</h1>
   <p><strong>Your own self-evolving AI agent</strong></p>
   <p>A long-running agent that works in the chat apps you already use, calls tools, remembers context, and keeps improving through real-world use.</p>
-  <p><a href="./README.zh-CN.md">中文文档</a> | <a href="./README.ja.md">日本語</a></p>
+  <p><a href="./README.zh-CN.md">中文文档</a> | <a href="./README.ja.md">日本語</a> | <a href="./README.ko.md">한국어</a></p>
 </div>
 
 **NexAgent** is an AI agent built for real-world, long-running use.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -2,7 +2,7 @@
   <h1>NexAgent</h1>
   <p><strong>持续进化的专属 AI Agent</strong></p>
   <p>它可以长期运行，在你常用的聊天应用中工作，调用工具，保留上下文记忆，并在真实使用中持续进化。</p>
-  <p><a href="./README.md">English README</a> | <a href="./README.ja.md">日本語</a></p>
+  <p><a href="./README.md">English README</a> | <a href="./README.ja.md">日本語</a> | <a href="./README.ko.md">한국어</a></p>
 </div>
 
 NexAgent 是一个面向真实使用场景的 AI Agent。

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -2,7 +2,7 @@
   <h1>NexAgent</h1>
   <p><strong>持续进化的专属 AI Agent</strong></p>
   <p>它可以长期运行，在你常用的聊天应用中工作，调用工具，保留上下文记忆，并在真实使用中持续进化。</p>
-  <p><a href="./README.md">English README</a></p>
+  <p><a href="./README.md">English README</a> | <a href="./README.ja.md">日本語</a></p>
 </div>
 
 NexAgent 是一个面向真实使用场景的 AI Agent。


### PR DESCRIPTION
Add a full Japanese translation of README (README.ja.md).

Changes:
- **README.ja.md** — Full Japanese translation of the English README, covering all sections (introduction, features, install, quick start, chat apps, models, tools & skills, architecture, etc.)
- **README.md** — Added link to Japanese version alongside the existing Chinese link
- **README.zh-CN.md** — Added link to Japanese version alongside the existing English link

Refs #12